### PR TITLE
fix(zsh): add missing linux_distribution function in 00_header.zsh

### DIFF
--- a/config/zsh/00_header.zsh
+++ b/config/zsh/00_header.zsh
@@ -2,7 +2,24 @@
 # * zsh内で使用する関数群
 ## =============================
 
-# estimate os  
+# estimate distribution name
+linux_distribution() {
+  if [ -f /etc/debian_version ]; then
+    if [ "$(awk -F= '/DISTRIB_ID/ {print $2}' /etc/lsb-release 2>/dev/null)" = "Ubuntu" ]; then
+      echo ubuntu
+    else
+      echo debian
+    fi
+  elif [ -f /etc/arch-release ]; then
+    echo archlinux
+  elif [[ -d /system/app/ && -d /system/priv-app ]]; then
+    echo android
+  else
+    echo unkown_linux
+  fi
+}
+
+# estimate os
 detect_os() {
   case "$(uname -s)" in
     Linux|GNU*)


### PR DESCRIPTION
## 概要

Linux 環境で zsh を起動すると以下のエラーが出ていた問題を修正します。

```
detect_os:3: command not found: linux_distribution
```

## 原因

`config/zsh/00_header.zsh` の `detect_os()` は Linux 環境で `linux_distribution` を呼び出すが、`linux_distribution` は `etc/lib/header.sh` にしか定義されていなかった。

zsh は `00_header.zsh` のみを読み込むため、Linux 上で `10_environment.zsh` / `20_alias.zsh` が `$(detect_os)` を評価したタイミングでこのエラーが発生していた。

エラー先頭の `detect_os:3:` は zsh 特有の「関数名:関数内オフセット」形式で、この不具合が zsh 側でのみ再現することとも整合する。

## 修正内容

`etc/lib/header.sh` と同じ `linux_distribution` 関数を `config/zsh/00_header.zsh` にも追加し、zsh ランタイムでも両関数が使えるようにした。

## 動作確認

- Linux (対象): エラーが解消されることを確認
- macOS: `detect_os` は `Darwin` ブランチで `echo darwin` に分岐するため影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)