### PR TITLE
Fix Linux deploy failure (no-op mv) and Docker local test harness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,11 +162,17 @@ jobs:
           cd test/docker
           setup_repo="${{ github.event.pull_request.head.repo.full_name || github.repository }}"
           setup_ref="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          # Mount the checkout so the "local" install method tests THIS
+          # commit (test_install.sh falls back to cloning GitHub master
+          # when ~/dotfiles-local is absent, which would silently skip
+          # validating the PR's changes). Harmless for "remote", which
+          # never reads the mount.
           docker run --rm \
             -e CI=true \
             -e DOTFILES_BOOTSTRAP_URL="https://raw.githubusercontent.com/${setup_repo}/refs/heads/${setup_ref}/etc/bootstrap" \
             -e DOTFILES_GITHUB="https://github.com/${setup_repo}.git" \
             -e DOTFILES_BRANCH="${setup_ref}" \
+            -v "${GITHUB_WORKSPACE}:/home/testuser/dotfiles-local:ro" \
             dotfiles-test:${{ matrix.os }} ./test_install.sh ${{ matrix.install }}
 
   syntax-check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,11 +162,6 @@ jobs:
           cd test/docker
           setup_repo="${{ github.event.pull_request.head.repo.full_name || github.repository }}"
           setup_ref="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-          # Mount the checkout so the "local" install method tests THIS
-          # commit (test_install.sh falls back to cloning GitHub master
-          # when ~/dotfiles-local is absent, which would silently skip
-          # validating the PR's changes). Harmless for "remote", which
-          # never reads the mount.
           docker run --rm \
             -e CI=true \
             -e DOTFILES_BOOTSTRAP_URL="https://raw.githubusercontent.com/${setup_repo}/refs/heads/${setup_ref}/etc/bootstrap" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ The one-liner `etc/bootstrap` downloads the GitHub **tarball** (`master.tar.gz`)
 - `test/tart/` - **Real** macOS VM tests via Tart on Apple Silicon (see below)
 
 ### Docker Linux tests: local vs remote
-- The `*-local` targets (`test-ubuntu-local` / `test-archlinux-local` in `test/docker/Makefile`) must use the compose services `ubuntu-local` / `archlinux-local`, which **mount the working tree** (`../../` → `~/dotfiles-local`) — uncommitted changes ARE tested. (Fixed 2026-07: they previously called the unmounted `test` service, so `test_install.sh` silently fell back to cloning GitHub master and local changes were never exercised.)
+- The `*-local` targets (`test-ubuntu-local` / `test-archlinux-local` in `test/docker/Makefile`) must use the compose services `ubuntu-local` / `archlinux-local`, which **mount the working tree** — uncommitted changes ARE tested. Without the mount, `test_install.sh` silently falls back to cloning GitHub master.
 - The `*-remote` targets run the `curl | bash` bootstrap against GitHub `master` — local changes are NOT covered until pushed.
 
 ### Real macOS Testing via Tart (Apple Silicon host required)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,10 @@ The one-liner `etc/bootstrap` downloads the GitHub **tarball** (`master.tar.gz`)
 - `test/docker/Dockerfile.macos` - **Fake** macOS env (Ubuntu + `OSTYPE=darwin`); smoke test only
 - `test/tart/` - **Real** macOS VM tests via Tart on Apple Silicon (see below)
 
+### Docker Linux tests: local vs remote
+- The `*-local` targets (`test-ubuntu-local` / `test-archlinux-local` in `test/docker/Makefile`) must use the compose services `ubuntu-local` / `archlinux-local`, which **mount the working tree** (`../../` → `~/dotfiles-local`) — uncommitted changes ARE tested. (Fixed 2026-07: they previously called the unmounted `test` service, so `test_install.sh` silently fell back to cloning GitHub master and local changes were never exercised.)
+- The `*-remote` targets run the `curl | bash` bootstrap against GitHub `master` — local changes are NOT covered until pushed.
+
 ### Real macOS Testing via Tart (Apple Silicon host required)
 For reproducing and fixing macOS-only failures (curl one-liner errors, missing
 `git` at deploy time, hung `xcode-select --install`, etc.), use the Tart-based

--- a/etc/scripts/deploy
+++ b/etc/scripts/deploy
@@ -84,7 +84,6 @@ else
     [ -z "${CI:-}" ] && [ -z "${DOTFILES_TEST:-}" ] && passphrase="-"
 
     ssh-keygen -q -f "$HOME"/.ssh/github-key -N "$passphrase"
-    mv "$HOME"/.ssh/github-key.pub "$HOME"/.ssh/github-key.pub
   fi
 fi
 

--- a/test/docker/Makefile
+++ b/test/docker/Makefile
@@ -27,7 +27,7 @@ test-ubuntu-remote: ## Test Ubuntu with remote installation
 	OS=ubuntu INSTALL_METHOD=remote docker compose run --rm test
 
 test-ubuntu-local: ## Test Ubuntu with local installation
-	OS=ubuntu INSTALL_METHOD=local docker compose run --rm test
+	docker compose run --rm ubuntu-local
 
 # Arch Linux tests
 test-archlinux: test-archlinux-remote test-archlinux-local ## Run all Arch Linux tests
@@ -36,7 +36,7 @@ test-archlinux-remote: ## Test Arch Linux with remote installation
 	OS=archlinux INSTALL_METHOD=remote docker compose run --rm test
 
 test-archlinux-local: ## Test Arch Linux with local installation
-	OS=archlinux INSTALL_METHOD=local docker compose run --rm test
+	docker compose run --rm archlinux-local
 
 # Interactive shell
 shell: ## Start interactive shell for debugging


### PR DESCRIPTION
## Summary

Two bugs found by running the Docker-based Ubuntu install tests against the working tree:

### 1. `make deploy` fails on every fresh Linux environment
`etc/scripts/deploy` line 87 ran `mv "$HOME"/.ssh/github-key.pub "$HOME"/.ssh/github-key.pub` right after `ssh-keygen`. Since `ssh-keygen -f github-key` already creates `github-key.pub`, this is a same-file `mv`, which GNU mv rejects ("are the same file"). With `set -euo pipefail` + the ERR trap, the whole deploy aborts:

```
[+] ssh...
mv: '/home/testuser/.ssh/github-key.pub' and '/home/testuser/.ssh/github-key.pub' are the same file
Error: /home/testuser/.dotfiles/etc/scripts/deploy:87 stopped
make: *** [Makefile:23: deploy] Error 1
```

**Fix:** delete the no-op `mv`.

### 2. "Local" Docker tests never tested local changes
`test-ubuntu-local` / `test-archlinux-local` in `test/docker/Makefile` invoked the `test` compose service, which has no volume mount. Inside the container, `test_install.sh` found no `~/dotfiles-local` and silently fell back to cloning GitHub `master` — so `make test-docker` could never validate uncommitted fixes.

**Fix:** use the already-defined `ubuntu-local` / `archlinux-local` services, which mount the working tree read-only.

Also documented the local-vs-remote test behavior in CLAUDE.md.

## Test plan

- [x] `docker compose run --rm ubuntu-local` — exit 0, 27/27 checks passed (deploy + symlinks + Bats)
- [x] `docker compose run --rm archlinux-local` — exit 0, 27/27 checks passed (regression)
- [x] `OS=ubuntu docker compose run --rm bats` — 8/8 ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)